### PR TITLE
Implement :ats option.

### DIFF
--- a/lib/clockwork.rb
+++ b/lib/clockwork.rb
@@ -68,10 +68,15 @@ module Clockwork
 	end
 
 	def every(period, job, options={}, &block)
-		event = Event.new(period, job, block || get_handler, options)
 		@@events ||= []
-		@@events << event
-		event
+		if options[:ats]
+			options.delete(:ats).each do |at|
+				options[:at] = at
+				register(period, job, block, options)
+			end
+		else
+			register(period, job, block, options)
+		end
 	end
 
 	def run
@@ -102,6 +107,13 @@ module Clockwork
 	def clear!
 		@@events = []
 		@@handler = nil
+	end
+
+	private
+	def register(period, job, block, options)
+		event = Event.new(period, job, block || get_handler, options)
+		@@events << event
+		event
 	end
 	
 end

--- a/test/clockwork_test.rb
+++ b/test/clockwork_test.rb
@@ -56,6 +56,18 @@ class ClockworkTest < Test::Unit::TestCase
 		assert_will_run Time.parse('jan 2 2010 16:20:00')
 	end
 
+	test "twice a day at 16:20 and 18:10" do
+		Clockwork.every(1.day, 'myjob', :ats => ['16:20', '18:10'])
+
+		assert_wont_run Time.parse('jan 1 2010 16:19:59')
+		assert_will_run Time.parse('jan 1 2010 16:20:00')
+		assert_wont_run Time.parse('jan 1 2010 16:20:01')
+
+		assert_wont_run Time.parse('jan 1 2010 18:09:59')
+		assert_will_run Time.parse('jan 1 2010 18:10:00')
+		assert_wont_run Time.parse('jan 1 2010 18:10:01')
+	end
+
 	test "aborts when no handler defined" do
 		Clockwork.clear!
 		assert_raise(Clockwork::NoHandlerDefined) do


### PR DESCRIPTION
Specify multiple 'at' times in a line, for an action.

This prevent an user from copy-and-pasting his action (or generating by a loop).
